### PR TITLE
fix bug: Some mj prompts may return a "FAILURE" status

### DIFF
--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -472,6 +472,12 @@ export const useChatStore = create<ChatStore>()(
                             Locale.Midjourney.UnknownReason;
                           isFinished = true;
                           break;
+                        case "FAILURE":
+                          content =
+                            statusResJson.failReason ||
+                            Locale.Midjourney.UnknownReason;
+                          isFinished = true;
+                          break;
                         case "NOT_START":
                           content = Locale.Midjourney.TaskNotStart;
                           break;


### PR DESCRIPTION
Some mj prompts may return a "FAILURE" status, causing infinite repeated requests.