### PR TITLE
Fixed a docker build error and added allow specifying a second image (the referred image) in /IMAGINE (垫图) command with --sref parameter

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/app/core/midjourney.ts
+++ b/app/core/midjourney.ts
@@ -56,6 +56,15 @@ export class MidjourneyApi {
                 const uploadRes: any = await this.uploadImage(data.images[0], true)
                 prompt = uploadRes.url + " " + prompt
             }
+            if (((data.images?.length || 0) > 1)) {
+                const promptTmp = (prompt as string).trimEnd()
+                if (promptTmp.endsWith('--sref')) {
+                    // upload the second image
+                    const uploadRes2: any = await this.uploadImage(data.images[1], true)
+                    console.log('The second image was uploaded successfully. Url = ' + uploadRes2.url)
+                    prompt = promptTmp + " " + uploadRes2.url
+                }
+            }
             this.taskCall(taskId, this.client?.Imagine(
                 prompt,
                 this.taskLoading(taskId)


### PR DESCRIPTION
1. The docker build error - 'cannot copy to non-directory'

When I run the docker build command on my machine (macOS Big Sur 11.7.8 ), it outputs an error:

ERROR: failed to solve: cannot copy to non-directory: /var/lib/docker/overlay2/orftejgghqupbrqx7gxckwla0/merged/app/node_modules/@eslint/eslintrc

It's caused by the 'COPY . . ' command.

In the Dockerfile:

      `WORKDIR /app
       COPY --from=deps /app/node_modules ./node_modules
       COPY . .
       RUN npm run build`

 The node_modules directory was copied to the current directory already. So no need to copy it again.

I added a .dockerignore with an 'node_modules' entry. Then I run the docker build again and the problem is solved.

2. The /IMAGINE (垫图) command only support one image
![image](https://github.com/Licoy/ChatGPT-Midjourney/assets/7850789/273c75b6-39ac-4710-8df4-cf58b22b905e)

But when using the --sref parameter, another image is need.

I upload the second image and added the url to the end when the --sref parameter is provided.

Anyone can test the feature with the image I built (docker pull yaohui758178454/chatgpt-midjourney:v3.2.3.1)