### PR TITLE
⭐ Fix preferentially using mjpApiKey

### DIFF
--- a/app/api/mj/[...path]/route.ts
+++ b/app/api/mj/[...path]/route.ts
@@ -59,10 +59,10 @@ async function handle(
     });
   }
 
-  const bearToken = req.headers.get("Authorization") ?? "";
-  const token = bearToken.trim().replaceAll("Bearer ", "").trim();
+  const bearToken = req.headers.get("Authorization")?.trim() ?? "";
+  const token = bearToken.startsWith("Bearer ") ? bearToken.slice(7).trim() : bearToken;
 
-  const key = token ? token : serverConfig.mjpApiKey;
+  const key = serverConfig.mjpApiKey || token;
 
   if (!key) {
     return NextResponse.json(


### PR DESCRIPTION
### Describe the bug

最新版的ChatGPT-Midjourney

环境变量MJ_PROXY_KEY无效，midjourney优先使用OPENAI_API_KEY的值进行请求

希望大大修复这个问题，十分感谢！！！

